### PR TITLE
Updating leader change alert to be consistent with CEO

### DIFF
--- a/alert-profiles/etcdapi-alerts.yml
+++ b/alert-profiles/etcdapi-alerts.yml
@@ -12,7 +12,7 @@
   description: 2 minutes avg. etcd network peer round trip on {{$labels.pod}} higher than 100ms. {{$value}}s
   severity: warning
 
-- expr: increase(etcd_server_leader_changes_seen_total[2m]) > 0
+- expr: avg(changes(etcd_server_is_leader[10m])) > 5
   description: etcd leader changes observed
   severity: error
 


### PR DESCRIPTION
ensuring it stays similar to https://github.com/openshift/cluster-etcd-operator/blob/master/jsonnet/custom.libsonnet#L57-L68

There was a bug when it comes to use "increase": https://bugzilla.redhat.com/show_bug.cgi?id=2092880